### PR TITLE
feat: Implementa endpoint de resumo de avaliacacoes do terapeuta

### DIFF
--- a/src/main/java/com/br/mindeasy/controller/AvaliacaoController.java
+++ b/src/main/java/com/br/mindeasy/controller/AvaliacaoController.java
@@ -1,0 +1,24 @@
+package com.br.mindeasy.controller;
+
+import com.br.mindeasy.dto.response.AvaliacaoResponseDTO;
+import com.br.mindeasy.service.AvaliacaoService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/avaliacoes")
+public class AvaliacaoController {
+
+    @Autowired
+    private AvaliacaoService avaliacaoService;
+
+    @GetMapping("/resumo/terapeuta/{idTerapeuta}")
+    public ResponseEntity<AvaliacaoResponseDTO> getResumo(@PathVariable Long idTerapeuta) {
+        AvaliacaoResponseDTO resumo = avaliacaoService.getResumoAvaliacoes(idTerapeuta);
+        return ResponseEntity.ok(resumo);
+    }
+}

--- a/src/main/java/com/br/mindeasy/dto/response/AvaliacaoResponseDTO.java
+++ b/src/main/java/com/br/mindeasy/dto/response/AvaliacaoResponseDTO.java
@@ -1,0 +1,61 @@
+package com.br.mindeasy.dto.response;
+public class AvaliacaoResponseDTO {
+
+    private long totalAvaliacoes;
+    private long avaliacoesDe1Estrela;
+    private long avaliacoesDe2Estrelas;
+    private long avaliacoesDe3Estrelas;
+    private long avaliacoesDe4Estrelas;
+    private long avaliacoesDe5Estrelas;
+
+    public AvaliacaoResponseDTO() {
+    }
+
+    public long getTotalAvaliacoes() {
+        return totalAvaliacoes;
+    }
+
+    public void setTotalAvaliacoes(long totalAvaliacoes) {
+        this.totalAvaliacoes = totalAvaliacoes;
+    }
+
+    public long getAvaliacoesDe1Estrela() {
+        return avaliacoesDe1Estrela;
+    }
+
+    public void setAvaliacoesDe1Estrela(long avaliacoesDe1Estrela) {
+        this.avaliacoesDe1Estrela = avaliacoesDe1Estrela;
+    }
+
+    public long getAvaliacoesDe2Estrelas() {
+        return avaliacoesDe2Estrelas;
+    }
+
+    public void setAvaliacoesDe2Estrelas(long avaliacoesDe2Estrelas) {
+        this.avaliacoesDe2Estrelas = avaliacoesDe2Estrelas;
+    }
+
+    public long getAvaliacoesDe3Estrelas() {
+        return avaliacoesDe3Estrelas;
+    }
+
+    public void setAvaliacoesDe3Estrelas(long avaliacoesDe3Estrelas) {
+        this.avaliacoesDe3Estrelas = avaliacoesDe3Estrelas;
+    }
+
+    public long getAvaliacoesDe4Estrelas() {
+        return avaliacoesDe4Estrelas;
+    }
+
+    public void setAvaliacoesDe4Estrelas(long avaliacoesDe4Estrelas) {
+        this.avaliacoesDe4Estrelas = avaliacoesDe4Estrelas;
+    }
+
+    public long getAvaliacoesDe5Estrelas() {
+        return avaliacoesDe5Estrelas;
+    }
+
+    public void setAvaliacoesDe5Estrelas(long avaliacoesDe5Estrelas) {
+        this.avaliacoesDe5Estrelas = avaliacoesDe5Estrelas;
+    }
+}

--- a/src/main/java/com/br/mindeasy/model/Agendamento.java
+++ b/src/main/java/com/br/mindeasy/model/Agendamento.java
@@ -1,0 +1,102 @@
+package com.br.mindeasy.model;
+
+import jakarta.persistence.*;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Entity
+@Table(name = "agendamentos")
+public class Agendamento {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "paciente_id", nullable = false)
+    private Paciente paciente;
+
+    @ManyToOne
+    @JoinColumn(name = "terapeuta_id", nullable = false)
+    private Terapeuta terapeuta;
+
+    @Column(nullable = false)
+    private LocalDate data;
+
+    @Column(nullable = false)
+    private LocalTime horaInicio;
+
+    private String status;
+
+    private Integer avaliacaoNota;
+
+    @Column(length = 500)
+    private String avaliacaoComentario;
+
+    public Agendamento() {
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Paciente getPaciente() {
+        return paciente;
+    }
+
+    public void setPaciente(Paciente paciente) {
+        this.paciente = paciente;
+    }
+
+    public Terapeuta getTerapeuta() {
+        return terapeuta;
+    }
+
+    public void setTerapeuta(Terapeuta terapeuta) {
+        this.terapeuta = terapeuta;
+    }
+
+    public LocalDate getData() {
+        return data;
+    }
+
+    public void setData(LocalDate data) {
+        this.data = data;
+    }
+
+    public LocalTime getHoraInicio() {
+        return horaInicio;
+    }
+
+    public void setHoraInicio(LocalTime horaInicio) {
+        this.horaInicio = horaInicio;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public Integer getAvaliacaoNota() {
+        return avaliacaoNota;
+    }
+
+    public void setAvaliacaoNota(Integer avaliacaoNota) {
+        this.avaliacaoNota = avaliacaoNota;
+    }
+
+    public String getAvaliacaoComentario() {
+        return avaliacaoComentario;
+    }
+
+    public void setAvaliacaoComentario(String avaliacaoComentario) {
+        this.avaliacaoComentario = avaliacaoComentario;
+    }
+}

--- a/src/main/java/com/br/mindeasy/repository/AgendamentoRepository.java
+++ b/src/main/java/com/br/mindeasy/repository/AgendamentoRepository.java
@@ -1,0 +1,20 @@
+package com.br.mindeasy.repository;
+
+import com.br.mindeasy.model.Agendamento;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface AgendamentoRepository extends JpaRepository<Agendamento, Long> {
+
+    @Query("""
+        SELECT a.avaliacaoNota, COUNT(a.avaliacaoNota)
+        FROM Agendamento a
+        WHERE a.terapeuta.id = :terapeutaId AND a.avaliacaoNota IS NOT NULL
+        GROUP BY a.avaliacaoNota
+    """)
+    List<Object[]> countAvaliacoesByNota(@Param("terapeutaId") Long terapeutaId);
+
+}

--- a/src/main/java/com/br/mindeasy/security/SecurityConfig.java
+++ b/src/main/java/com/br/mindeasy/security/SecurityConfig.java
@@ -14,43 +14,45 @@ import org.springframework.security.web.SecurityFilterChain;
 @Configuration
 public class SecurityConfig {
 
-        @Bean
-        public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-                http
-                                .cors(Customizer.withDefaults())
-                                .csrf(csrf -> csrf.disable())
-                                .authorizeHttpRequests(auth -> auth
-                                                .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
-                                                .requestMatchers(
-                                                                "/src/**",
-                                                                "/swagger-ui.html",
-                                                                "/swagger-ui/**",
-                                                                "/v3/api-docs/**",
-                                                                "/swagger-resources/**",
-                                                                "/paciente/**",
-                                                                "/terapeuta/**")
-                                                .permitAll()
-                                                .anyRequest().authenticated())
-                                .headers(headers -> headers
-                                                .frameOptions(frame -> frame.disable()))
-                                .httpBasic(Customizer.withDefaults());
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .cors(Customizer.withDefaults())
+            .csrf(csrf -> csrf.disable())
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                .requestMatchers(
+                    "/src/**",
+                    "/swagger-ui.html",
+                    "/swagger-ui/**",
+                    "/v3/api-docs/**",
+                    "/swagger-resources/**",
+                    "/paciente/**",
+                    "/terapeuta/**",
+                    "/api/avaliacoes/**" // <-- LINHA ADICIONADA PARA LIBERAR O TESTE
+                )
+                .permitAll()
+                .anyRequest().authenticated())
+            .headers(headers -> headers
+                .frameOptions(frame -> frame.disable()))
+            .httpBasic(Customizer.withDefaults());
 
-                return http.build();
-        }
+        return http.build();
+    }
 
-        @Bean
-        public AuthenticationManager authManager(
-                        HttpSecurity http,
-                        UserDetailsServiceConfig userDetailsService) throws Exception {
-                var authBuilder = http.getSharedObject(AuthenticationManagerBuilder.class);
-                authBuilder
-                                .userDetailsService(userDetailsService)
-                                .passwordEncoder(passwordEncoder());
-                return authBuilder.build();
-        }
+    @Bean
+    public AuthenticationManager authManager(
+            HttpSecurity http,
+            UserDetailsServiceConfig userDetailsService) throws Exception {
+        var authBuilder = http.getSharedObject(AuthenticationManagerBuilder.class);
+        authBuilder
+            .userDetailsService(userDetailsService)
+            .passwordEncoder(passwordEncoder());
+        return authBuilder.build();
+    }
 
-        @Bean
-        public PasswordEncoder passwordEncoder() {
-                return PasswordEncoderFactories.createDelegatingPasswordEncoder();
-        }
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
 }

--- a/src/main/java/com/br/mindeasy/service/AvaliacaoService.java
+++ b/src/main/java/com/br/mindeasy/service/AvaliacaoService.java
@@ -1,0 +1,62 @@
+package com.br.mindeasy.service;
+
+import com.br.mindeasy.dto.response.AvaliacaoResponseDTO;
+import com.br.mindeasy.repository.AgendamentoRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class AvaliacaoService {
+
+    @Autowired
+    private AgendamentoRepository agendamentoRepository;
+
+    public AvaliacaoResponseDTO getResumoAvaliacoes(Long terapeutaId) {
+        List<Object[]> resultadosDoBanco = agendamentoRepository.countAvaliacoesByNota(terapeutaId);
+
+        long contagem1Estrela = 0;
+        long contagem2Estrelas = 0;
+        long contagem3Estrelas = 0;
+        long contagem4Estrelas = 0;
+        long contagem5Estrelas = 0;
+
+        for (Object[] resultado : resultadosDoBanco) {
+            Integer nota = (Integer) resultado[0];
+            Long contagem = (Long) resultado[1];
+
+            if (nota != null) {
+                 switch (nota) {
+                    case 1:
+                        contagem1Estrela = contagem;
+                        break;
+                    case 2:
+                        contagem2Estrelas = contagem;
+                        break;
+                    case 3:
+                        contagem3Estrelas = contagem;
+                        break;
+                    case 4:
+                        contagem4Estrelas = contagem;
+                        break;
+                    case 5:
+                        contagem5Estrelas = contagem;
+                        break;
+                }
+            }
+        }
+
+        long totalDeAvaliacoes = contagem1Estrela + contagem2Estrelas + contagem3Estrelas + contagem4Estrelas + contagem5Estrelas;
+
+        AvaliacaoResponseDTO resumoDto = new AvaliacaoResponseDTO();
+        resumoDto.setTotalAvaliacoes(totalDeAvaliacoes);
+        resumoDto.setAvaliacoesDe1Estrela(contagem1Estrela);
+        resumoDto.setAvaliacoesDe2Estrelas(contagem2Estrelas);
+        resumoDto.setAvaliacoesDe3Estrelas(contagem3Estrelas);
+        resumoDto.setAvaliacoesDe4Estrelas(contagem4Estrelas);
+        resumoDto.setAvaliacoesDe5Estrelas(contagem5Estrelas);
+
+        return resumoDto;
+    }
+}


### PR DESCRIPTION
Este PR implementa o back-end para a funcionalidade de resumo de avaliações do terapeuta. 
O objetivo é prover os dados agregados necessários para a construção de um gráfico de avaliações no perfil do terapeuta.

O que foi feito:
- Criação do endpoint GET /api/avaliacoes/resumo/terapeuta/{idTerapeuta}.
- A resposta retorna um JSON com a contagem total de avaliações e o total por nota (1 a 5).
- A lógica utiliza uma query JPQL customizada (@Query) para agregar os dados diretamente no banco, garantindo a performance.
- Adicionados os arquivos necessários: AvaliacaoResponseDTO, AvaliacaoService e AvaliacaoController.
- O SecurityConfig foi atualizado para permitir o teste do novo endpoint.

Como Testar:
- Garanta que existem agendamentos avaliados para um terapeuta no banco de dados.
- Faça uma requisição GET para /api/avaliacoes/resumo/terapeuta/{id} (substituindo {id} por um ID válido).
- Verifique se a resposta é 200 OK e se o JSON contém as contagens corretas.