### PR TITLE
feat(avaliacoes): Implementa CRUD para gerenciamento de avaliações

### DIFF
--- a/src/main/java/com/br/mindeasy/controller/AvaliacaoController.java
+++ b/src/main/java/com/br/mindeasy/controller/AvaliacaoController.java
@@ -1,13 +1,11 @@
 package com.br.mindeasy.controller;
 
+import com.br.mindeasy.dto.request.AvaliacaoRequestDTO;
 import com.br.mindeasy.dto.response.AvaliacaoResponseDTO;
 import com.br.mindeasy.service.AvaliacaoService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/avaliacoes")
@@ -21,4 +19,23 @@ public class AvaliacaoController {
         AvaliacaoResponseDTO resumo = avaliacaoService.getResumoAvaliacoes(idTerapeuta);
         return ResponseEntity.ok(resumo);
     }
+
+    @PostMapping("/agendamentos/{id}/avaliacao")
+    public ResponseEntity<AvaliacaoResponseDTO> criarAvaliacao(@PathVariable Long id, @RequestBody AvaliacaoRequestDTO dto) {
+        AvaliacaoResponseDTO resumoAtualizado = avaliacaoService.criarAvaliacao(id, dto);
+        return ResponseEntity.status(201).body(resumoAtualizado);
+    }
+
+    @PutMapping("/agendamentos/{id}/avaliacao")
+    public ResponseEntity<AvaliacaoResponseDTO> atualizarAvaliacao(@PathVariable Long id, @RequestBody AvaliacaoRequestDTO dto) {
+        AvaliacaoResponseDTO resumoAtualizado = avaliacaoService.atualizarAvaliacao(id, dto);
+        return ResponseEntity.ok(resumoAtualizado);
+    }
+
+    @DeleteMapping("/agendamentos/{id}/avaliacao")
+public ResponseEntity<Void> removerAvaliacao(@PathVariable Long id) {
+    avaliacaoService.removerAvaliacao(id);
+    return ResponseEntity.noContent().build();
+}
+
 }

--- a/src/main/java/com/br/mindeasy/dto/request/AvaliacaoRequestDTO.java
+++ b/src/main/java/com/br/mindeasy/dto/request/AvaliacaoRequestDTO.java
@@ -1,0 +1,26 @@
+package com.br.mindeasy.dto.request;
+
+public class AvaliacaoRequestDTO {
+
+    private Integer nota;
+    private String comentario;
+
+    public AvaliacaoRequestDTO() {
+    }
+
+    public Integer getNota() {
+        return nota;
+    }
+
+    public void setNota(Integer nota) {
+        this.nota = nota;
+    }
+
+    public String getComentario() {
+        return comentario;
+    }
+
+    public void setComentario(String comentario) {
+        this.comentario = comentario;
+    }
+}

--- a/src/main/java/com/br/mindeasy/service/AvaliacaoService.java
+++ b/src/main/java/com/br/mindeasy/service/AvaliacaoService.java
@@ -1,6 +1,8 @@
 package com.br.mindeasy.service;
 
+import com.br.mindeasy.dto.request.AvaliacaoRequestDTO;
 import com.br.mindeasy.dto.response.AvaliacaoResponseDTO;
+import com.br.mindeasy.model.Agendamento;
 import com.br.mindeasy.repository.AgendamentoRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -27,7 +29,7 @@ public class AvaliacaoService {
             Long contagem = (Long) resultado[1];
 
             if (nota != null) {
-                 switch (nota) {
+                switch (nota) {
                     case 1:
                         contagem1Estrela = contagem;
                         break;
@@ -59,4 +61,47 @@ public class AvaliacaoService {
 
         return resumoDto;
     }
+
+    public AvaliacaoResponseDTO criarAvaliacao(Long agendamentoId, AvaliacaoRequestDTO dto) {
+        Agendamento agendamento = agendamentoRepository.findById(agendamentoId)
+                .orElseThrow(() -> new RuntimeException("Agendamento não encontrado"));
+
+        if (agendamento.getAvaliacaoNota() != null) {
+            throw new RuntimeException("Este agendamento já foi avaliado.");
+        }
+
+        agendamento.setAvaliacaoNota(dto.getNota());
+        agendamento.setAvaliacaoComentario(dto.getComentario());
+
+        agendamentoRepository.save(agendamento);
+
+        return getResumoAvaliacoes(agendamento.getTerapeuta().getId());
+    }
+
+    public AvaliacaoResponseDTO atualizarAvaliacao(Long agendamentoId, AvaliacaoRequestDTO dto) {
+        Agendamento agendamento = agendamentoRepository.findById(agendamentoId)
+                .orElseThrow(() -> new RuntimeException("Agendamento não encontrado"));
+
+        if (agendamento.getAvaliacaoNota() == null) {
+            throw new RuntimeException("Este agendamento ainda não foi avaliado. Crie uma avaliação antes de atualizar.");
+        }
+
+        agendamento.setAvaliacaoNota(dto.getNota());
+        agendamento.setAvaliacaoComentario(dto.getComentario());
+
+        agendamentoRepository.save(agendamento);
+
+        return getResumoAvaliacoes(agendamento.getTerapeuta().getId());
+    }
+
+    public void removerAvaliacao(Long agendamentoId) {
+    Agendamento agendamento = agendamentoRepository.findById(agendamentoId)
+            .orElseThrow(() -> new RuntimeException("Agendamento não encontrado"));
+
+    agendamento.setAvaliacaoNota(null);
+    agendamento.setAvaliacaoComentario(null);
+
+    agendamentoRepository.save(agendamento);
+}
+
 }


### PR DESCRIPTION
Este PR implementa o CRUD completo para o recurso de Avaliações, permitindo que um paciente possa criar, atualizar e remover sua avaliação de um agendamento.

**Mudanças Principais:**

Adicionado endpoint POST /api/agendamentos/{id}/avaliacao para criar uma nova avaliação.

Adicionado endpoint PUT /api/agendamentos/{id}/avaliacao para atualizar uma avaliação existente.

Adicionado endpoint DELETE /api/agendamentos/{id}/avaliacao para remover uma avaliação (limpando os campos no agendamento).

Criado o AvaliacaoRequestDTO para os dados de entrada (nota, comentario).

Expandido o AvaliacaoService com as novas regras de negócio.

**Como Testar:**

Com a aplicação rodando, use o Postman para testar os três endpoints (POST, PUT, DELETE).

Verifique se as operações refletem corretamente no banco de dados (criando, alterando e limpando os campos avaliacao_nota e avaliacao_comentario na tabela agendamentos).